### PR TITLE
[chore] mainuser base64코드삭제

### DIFF
--- a/server/src/main/java/com/my/kde_db/dto/MainUser.java
+++ b/server/src/main/java/com/my/kde_db/dto/MainUser.java
@@ -1,13 +1,9 @@
 package com.my.kde_db.dto;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 
 @Data
 public class MainUser {
     private String name=null;
-    @JsonIgnore
-    private byte[] image=null; //조회용 이미지
-    private String base64Image=null; //반환용 base64 인코딩한 이미지
+    private byte[] image=null; //응답할때 자동으로 base64인코딩되어 보내짐
     private int number=0;
 }

--- a/server/src/main/java/com/my/kde_db/service/MainPageService.java
+++ b/server/src/main/java/com/my/kde_db/service/MainPageService.java
@@ -15,12 +15,7 @@ public class MainPageService {
     MainPageMapper mainPageMapper;
 
     public MainUser getUser(int number){
-    MainUser mainuser=mainPageMapper.findUserByNumber(number);
-    if (mainuser != null && mainuser.getImage() != null){
-        String base64Image = Base64Utils.encode(mainuser.getImage());
-        mainuser.setBase64Image(base64Image);
-    }
-    return mainuser;
+    return mainPageMapper.findUserByNumber(number);
     }
 
     public List<MainPost> getHotPost(){


### PR DESCRIPTION
base64 코드 없이도 자동 base64인코딩 되기 때문에 base64 관련 코드 삭제

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 ✨
- [ ] 기능 삭제 🔥
- [ ] 버그 수정 🐛
- [x] 코드 형태 개선 🎨
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 🔨

### 변경 사항
데이터베이스 조회용 byte[] 이미지를 String base64Image 으로 인코딩해주는 코드가 필요없음.
자동으로 json으로 반환할때 byte[] 이미지를 base64로 인코딩해서 string으로 보내주고있다.
이미지 반환용 base64관련 코드는 없어도 무방함.

### 이슈 사항
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

### To reviewer
ex) 여기에서 이 부분 잘 모르겠는데 한번 봐주실 수 있나요?
