### PR TITLE
[fix] 캘린더 특정 날짜 일정 미표시 버그 수정

### DIFF
--- a/client/src/component/mainpage/calendar.js
+++ b/client/src/component/mainpage/calendar.js
@@ -108,7 +108,7 @@ function Calendar() {
           // 사용자가 추가하는 일정
           data.calendars.forEach(calendar => {
             const date = new Date(calendar.date);
-            date.setDate(date.getDate() + 1); // 일정이 하루 앞에서 표시가 되어서 하루 더함
+            date.setDate(date.getDate());
             const dateKey = date.toISOString().split('T')[0];
             if (!newEvents[dateKey]) newEvents[dateKey] = [];
             newEvents[dateKey].push(calendar.title);

--- a/client/src/component/mainpage/modalCalendar.js
+++ b/client/src/component/mainpage/modalCalendar.js
@@ -249,6 +249,16 @@ function Modal({ selectedDate, closeModal, addSchedule }) {
   const [schedules, setSchedules] = useState([]);
   const [scheduleNumber, setScheduleNumber] = useState(null);
 
+  //기존의 formattedDate를 하루 더함으로써 DB에 맞게 표시
+  const datePlusOneDay = new Date(selectedDate);
+  datePlusOneDay.setDate(datePlusOneDay.getDate() + 1);
+
+  //selectedDate가 맞게 나오는지 test
+  //console.log(selectedDate);
+
+  // DB에 시간을 맞게 post하기위해 ISO형식에 맞춘 formattedISO또한 하루 더하기. 
+  const formattedDateFixedISO = datePlusOneDay ? datePlusOneDay.toISOString() : '-';
+
   const fetchEvents = async () => {
     try {
       const year = selectedDate.getFullYear();
@@ -258,7 +268,7 @@ function Modal({ selectedDate, closeModal, addSchedule }) {
         const events = Array.isArray(response.data.calendars) ? response.data.calendars : [];
         const eventsForSelectedDate = events.filter(event => {
           const eventDate = new Date(event.date).toISOString().split('T')[0];
-          return eventDate === formattedDateISO.split('T')[0];
+          return eventDate === formattedDateFixedISO.split('T')[0];
         });
         const eventsWithId = eventsForSelectedDate.map(event => ({ ...event, id: event.number }));
         setSchedules(eventsWithId);
@@ -278,7 +288,7 @@ function Modal({ selectedDate, closeModal, addSchedule }) {
     }
 
     const newEvent = {
-      date: formattedDateISO,
+      date: formattedDateFixedISO,
       title: scheduleText,
     };
 
@@ -300,7 +310,7 @@ function Modal({ selectedDate, closeModal, addSchedule }) {
 
   const handleEditEvent = async () => {
     const editEvent = {
-      date: formattedDateISO,
+      date: formattedDateFixedISO,
       title: scheduleText,
       number: scheduleNumber,
     };
@@ -338,7 +348,7 @@ function Modal({ selectedDate, closeModal, addSchedule }) {
     if (selectedDate) {
       fetchEvents();
     }
-  }, [selectedDate, formattedDateISO]);
+  }, [selectedDate, formattedDateFixedISO]);
 
   return (
     <ModalWrapper>


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 ✨
- [ ] 기능 삭제 🔥
- [x] 버그 수정 🐛
- [ ] 코드 형태 개선 🎨
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 🔨

### 변경 사항
- calendar.js line 111 에서 일정을 하루 후에 표시 되도록 하던 코드를 해당 일로 표시하도록 수정하였습니다.
- modalCalendar.js에서 기존의 post하던 일정의 날짜를 하루 더하는 것으로 수정하였습니다.

### 이슈 사항
버그...라기보다는 그냥 잘못된 코드 작성이라고 할 수 있습니다.
calendar.js line 111에서 초기에 작성했던 코드가 문제였습니다. 이유는 적혀있지 않고 '일정이 하루 앞에서 표시가 되어서 하루 더함'이라는 주석과 함께 국제표준시 년,월,일을 가져오는 과정에서 일을 하루 더하여 오차가 생긴 듯 합니다만, 정확한 원인은 더 알아봐야 합니다.

### To reviewer
개강 이슈로 시간이 없어서 비교적 원인을 찾는데에는 시간이 걸릴 듯 합니다.
언젠가 여유가 되시면 같이 문제를 찾아보아요..^^
